### PR TITLE
Use the long name to specify the grub2 key protector

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -395,7 +395,7 @@ prepare_cryptodisk () {
 
   cat <<EOF
 tpm2_key_protector_init $tpm_mode -b $tpm_pcr_bank -p $tpm_pcr_list -k \$prefix/$tpm_sealed_key $tpm_extra_options
-if ! cryptomount -u $uuid -k tpm2; then
+if ! cryptomount -u $uuid --protector tpm2; then
     cryptomount -u $uuid
 fi
 EOF


### PR DESCRIPTION
Grub2 upstream merged a series of patches to provide cryptomount the key file to unlock the disk. Unfortunately, the short name (-k) of "--keyfile" conflicts with the one chosen by the grub2 TPM2 disk unlock patches. To avoid the compatibility issues, always use the long name (--protector) to specify the key protector for cryptomount.