### PR TITLE
Fix that bootx64.efi is not updated on Leap

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -60,6 +60,7 @@ fi
 if [ x"${GRUB_DISTRIBUTOR}" = x ] && [ -f "${sysconfdir}/os-release" ] ; then
     . "${sysconfdir}/os-release"
     GRUB_DISTRIBUTOR="${NAME} ${VERSION}"
+    OS_ID="${ID}"
 fi
 
 bootloader_id="$(echo "$GRUB_DISTRIBUTOR" | tr 'A-Z' 'a-z' | cut -d' ' -f1)"
@@ -76,6 +77,11 @@ case "$bootloader_id" in
     "opensuse"*)
         ca_string='openSUSE Secure Boot CA1';;
     *) ca_string="";;
+esac
+
+case "$OS_ID" in
+    "opensuse-leap")
+        ca_string='SUSE Linux Enterprise Secure Boot CA1';;
 esac
 
 is_azure () {


### PR DESCRIPTION
After closing Leap-gap project since Leap 15.3, openSUSE Leap direct uses shim from SLE. So the ca_string is 'SUSE Linux Enterprise Secure Boot CA1', not 'openSUSE Secure Boot CA1'. It causes that the update_boot=no, so all files in /boot/efi/EFI/boot are not updated.

This patch added the logic that using ID field in os-release for checking Leap distro and set ca_string to 'SUSE Linux Enterprise Secure Boot CA1'. Then /boot/efi/EFI/boot/* can also be updated.

Reference: https://bugzilla.suse.com/show_bug.cgi?id=1210382