### PR TITLE
Adopt TPM 2.0 Key File for grub2 TPM 2.0 protector

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -376,16 +376,7 @@ prepare_cryptodisk () {
     return
   fi
 
-  tpm_pcr_bank="${GRUB_TPM2_PCR_BANK:-sha256}"
-  tpm_pcr_list="${GRUB_TPM2_PCR_LIST:-0,2,4,7,9}"
   tpm_sealed_key="${GRUB_TPM2_SEALED_KEY}"
-
-  tpm_mode=""
-  tpm_extra_options=""
-  if [ -n "$GRUB_TPM_AUTHORIZED_POLICY" ]; then
-    tpm_mode="-m authpol"
-    tpm_extra_options="-P \$prefix/$GRUB_TPM_PUBLIC_KEY -S \$prefix/$GRUB_TPM_SIGNATURE"
-  fi
 
   declare -g TPM_PCR_SNAPSHOT_TAKEN
 
@@ -400,7 +391,7 @@ prepare_cryptodisk () {
   fi
 
   cat <<EOF
-tpm2_key_protector_init $tpm_mode -b $tpm_pcr_bank -p $tpm_pcr_list -k \$prefix/$tpm_sealed_key $tpm_extra_options
+tpm2_key_protector_init -T \$prefix/$tpm_sealed_key
 if ! cryptomount -u $uuid --protector tpm2; then
     cryptomount -u $uuid
 fi


### PR DESCRIPTION
With TPM 2.0 Key File support in grub2, there is no need to specify the details for the construction of the unsealing policy. All the necessary parameters are included in the key file itself, so we only need to specify the path to the key file in grub.cfg.