### PR TITLE
Add hint for encrypted devices

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -423,10 +423,11 @@ if [ x$GRUB_ENABLE_CRYPTODISK = xy ]; then
   for uuid in `"${grub_probe}" --target=cryptodisk_uuid --device-map= "${grub_cfg_dirname}"`; do
     prepare_cryptodisk "$uuid"
   done
+  cfg_fs_hint="--hint-efi="`"$grub_probe" --target=efi_hints "$grub_cfg_dirname"`
 fi
 
 cat <<EOF
-search --fs-uuid --set=root ${cfg_fs_uuid}
+search --fs-uuid --set=root ${cfg_fs_hint} ${cfg_fs_uuid}
 set prefix=(\${root})`${grub_mkrelpath} ${grub_cfg_dirname}`
 source "\${prefix}/${grub_cfg_basename}"
 EOF


### PR DESCRIPTION
When setting the root filesystem for encrypted devices, the 'search' command may look for another filesystem with the same fs-uuid. This commit adds a hint for 'search' to make the encrypted device first priority for search. For a system with a LUKS root, the hint may look like this:

   --hint-efi=cryptouuid/59091dcb03954a369a33dfb47c3a7f15