### PR TITLE
Use hint in looking for root if possible

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -423,11 +423,21 @@ if [ x$GRUB_ENABLE_CRYPTODISK = xy ]; then
   for uuid in `"${grub_probe}" --target=cryptodisk_uuid --device-map= "${grub_cfg_dirname}"`; do
     prepare_cryptodisk "$uuid"
   done
-  cfg_fs_hint="--hint-efi="`"$grub_probe" --target=efi_hints "$grub_cfg_dirname"`
+fi
+
+hints="`"${grub_probe}" --target=hints_string "${grub_cfg_dirname}" 2> /dev/null`"
+
+if [ "x$hints" != x ]; then
+  echo "if [ x\$feature_platform_search_hint = xy ]; then"
+  echo "  search --no-floppy --fs-uuid --set=root ${hints} ${cfg_fs_uuid}"
+  echo "else"
+  echo "  search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+  echo "fi"
+else
+  echo "search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
 fi
 
 cat <<EOF
-search --fs-uuid --set=root ${cfg_fs_hint} ${cfg_fs_uuid}
 set prefix=(\${root})`${grub_mkrelpath} ${grub_cfg_dirname}`
 source "\${prefix}/${grub_cfg_basename}"
 EOF


### PR DESCRIPTION
In grub, a search hint can be used to prioritize the order when iterating the devices to find a matching signature or property. The device specified in the hint will be tried first before any other devices.

As long the grub device containing a specific file or directory can be probed from a running linux system, we can just use the result as hint to the search of root device by looking for it's file system UUID. This can helpful in the situation:

1. The entire search process can be faster as the most possible device is tested first.

2. In some cases the file system UUID would have been duplicated due to disk mirror (RAID1/RAID10) or there's a cloned copy somewhere. The hint helps in differentiate due to it's order is prioritized.

Last but not least, we should avoid using the grub device name directly for the root because there's no guarantee it will always be the same. For example the disk order may have changed in bios so that to reflect the change the name is also changed. The grub may also introduce change to the name itself, although they are compatible for the most of time but still chance is there for a breaking change.