### PR TITLE
Support SRK algorithm and remove PCR snapshot

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -378,18 +378,6 @@ prepare_cryptodisk () {
 
   tpm_sealed_key="${GRUB_TPM2_SEALED_KEY}"
 
-  declare -g TPM_PCR_SNAPSHOT_TAKEN
-
-  if [ -z "$TPM_PCR_SNAPSHOT_TAKEN" ]; then
-    TPM_PCR_SNAPSHOT_TAKEN=1
-
-    # Check if tpm_record_pcrs is available and set the command to
-    # grub.cfg.
-    if grep -q "tpm_record_pcrs" ${datadir}/grub2/${arch}-efi/command.lst ; then
-      echo "tpm_record_pcrs 0-9"
-    fi
-  fi
-
   tpm_srk_alg="${GRUB_TPM2_SRK_ALG}"
 
   if [ -z "$tpm_srk_alg" ]; then

--- a/shim-install
+++ b/shim-install
@@ -390,8 +390,14 @@ prepare_cryptodisk () {
     fi
   fi
 
+  tpm_srk_alg="${GRUB_TPM2_SRK_ALG}"
+
+  if [ -z "$tpm_srk_alg" ]; then
+    tpm_srk_alg="RSA"
+  fi
+
   cat <<EOF
-tpm2_key_protector_init -T \$prefix/$tpm_sealed_key
+tpm2_key_protector_init -a $tpm_srk_alg -T \$prefix/$tpm_sealed_key
 if ! cryptomount -u $uuid --protector tpm2; then
     cryptomount -u $uuid
 fi


### PR DESCRIPTION
- Set the SRK algorithm for the sealed TPM key
- Remove the PCR snapshot command since pcr-oracle doesn't need it anymore