### PR TITLE
Improve shim-install regarding to grub's root device search

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -444,6 +444,7 @@ fi
 if [ x$GRUB_ENABLE_CRYPTODISK = xy ]; then
   for uuid in `"${grub_probe}" --target=cryptodisk_uuid --device-map= "${grub_cfg_dirname}"`; do
     prepare_cryptodisk "$uuid"
+    IS_CRYPTO_ROOT=y
   done
 fi
 
@@ -452,13 +453,31 @@ for hint in `"${grub_probe}" --target=efi_hints "${grub_cfg_dirname}" 2> /dev/nu
 done
 
 if [ "x$hints" != x ]; then
-  echo "if [ x\$feature_platform_search_hint = xy ]; then"
-  echo "  search --no-floppy --fs-uuid --set=root ${hints} ${cfg_fs_uuid}"
-  echo "else"
-  echo "  search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
-  echo "fi"
+  if [ "x$IS_CRYPTO_ROOT" = xy ]; then
+    echo "if [ x\$feature_search_cryptodisk_only = xy ]; then"
+    echo "  search --no-floppy --cryptodisk-only --fs-uuid --set=root ${hints} ${cfg_fs_uuid}"
+    echo "elif [ x\$feature_platform_search_hint = xy ]; then"
+    echo "  search --no-floppy --fs-uuid --set=root ${hints} ${cfg_fs_uuid}"
+    echo "else"
+    echo "  search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+    echo "fi"
+  else
+    echo "if [ x\$feature_platform_search_hint = xy ]; then"
+    echo "  search --no-floppy --fs-uuid --set=root ${hints} ${cfg_fs_uuid}"
+    echo "else"
+    echo "  search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+    echo "fi"
+  fi
 else
-  echo "search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+  if [ "x$IS_CRYPTO_ROOT" = xy ]; then
+    echo "if [ x\$feature_search_cryptodisk_only = xy ]; then"
+      echo "search --no-floppy --cryptodisk-only --fs-uuid --set=root ${cfg_fs_uuid}"
+    echo "else"
+      echo "search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+    echo "fi"
+  else
+    echo "search --no-floppy --fs-uuid --set=root ${cfg_fs_uuid}"
+  fi
 fi
 
 cat <<EOF

--- a/shim-install
+++ b/shim-install
@@ -447,7 +447,9 @@ if [ x$GRUB_ENABLE_CRYPTODISK = xy ]; then
   done
 fi
 
-hints="`"${grub_probe}" --target=hints_string "${grub_cfg_dirname}" 2> /dev/null`"
+for hint in `"${grub_probe}" --target=efi_hints "${grub_cfg_dirname}" 2> /dev/null`; do
+  hints="${hints:+$hints }--hint='$hint'"
+done
 
 if [ "x$hints" != x ]; then
   echo "if [ x\$feature_platform_search_hint = xy ]; then"


### PR DESCRIPTION
The first patch uses efi_hint to probe the device hint for the search command, offering better efficiency and reduced complexity compared to the hints_string, which covers all platforms.

The second patch enables the --cryptodisk-only option for the search command when the root device is encrypted. This mitigates attacks from fake roots crafted with forged filesystem UUIDs.