### PR TITLE
Fix the path to grub2 command.lst

### DIFF
--- a/shim-install
+++ b/shim-install
@@ -401,7 +401,7 @@ prepare_cryptodisk () {
 
     # Check if tpm_record_pcrs is available and set the command to
     # grub.cfg.
-    if grep -q "tpm_record_pcrs" ${datadir}/grub2/${arch}-efi/command.lst ; then
+    if grep -q "tpm_record_pcrs" ${datadir}/grub2/${grub_install_target}/command.lst ; then
       echo "tpm_record_pcrs 0-9"
     fi
   fi


### PR DESCRIPTION
The command check for tpm_record_pcrs is not correct on the AArch64 system. Fix the path to get the correct result.